### PR TITLE
Slider fixes

### DIFF
--- a/src/main/java/org/dwcj/controls/slider/Slider.java
+++ b/src/main/java/org/dwcj/controls/slider/Slider.java
@@ -32,10 +32,10 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
     public enum Orientation{
         HORIZONTAL("horizontal"), VERTICAL("vertical");
 
-        public final String orientation;
+        public final String value;
 
-        private Orientation(String orientation){
-            this.orientation = orientation;
+        private Orientation(String value){
+            this.value = value;
         }
     }
 

--- a/src/main/java/org/dwcj/controls/slider/Slider.java
+++ b/src/main/java/org/dwcj/controls/slider/Slider.java
@@ -467,7 +467,7 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
 
     @Override
     public Slider setText(String text) {
-        super.setText(text);
+        //does nothing for this control
         return this;
     }
 

--- a/src/main/java/org/dwcj/controls/slider/Slider.java
+++ b/src/main/java/org/dwcj/controls/slider/Slider.java
@@ -3,6 +3,8 @@ package org.dwcj.controls.slider;
 import com.basis.bbj.proxies.sysgui.BBjSlider;
 import com.basis.bbj.proxies.sysgui.BBjWindow;
 import com.basis.startup.type.BBjException;
+
+import org.dwcj.App;
 import org.dwcj.Environment;
 import org.dwcj.bridge.PanelAccessor;
 import org.dwcj.controls.AbstractDwcControl;
@@ -32,7 +34,6 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
     private SliderOnControlScrollEventSink scrollEventSink;
     
     private Boolean horizontal = true;
-    private Boolean inverted = false;
     private Integer majorTickSpacing = 1;
     private Integer minorTickSpacing = 1;
     private Integer maximum = 100;
@@ -74,6 +75,11 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
 
     }
 
+    /**
+     * Sets a callback to fire when the slider control is scrolled.
+     * @param callback Function written with behavior to be executed when the event is fired
+     * @return The object itself
+     */
     public Slider onScroll(Consumer<SliderOnControlScrollEvent> callback) {
         if(this.ctrl != null){
             if(this.scrollEventSink == null){
@@ -85,26 +91,6 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             this.callbacks.add(callback);
         }
         return this;
-    }
-
-    /*
-     * ==I tested the set method and no inversion happens, but this method does properly return the Boolean value
-     * if it's been changed== -MH
-     */
-
-    /**
-     * This method gets the orientation of the ProgressBar control. By default, the minimum value of a vertical slider is at the bottom and the maximum value is at the top. For a horizontal slider, the minimum value is to the left and the maximum value is to the right. The orientation reverses for inverted sliders.
-     * @return Returns whether the control orientation is inverted.
-     */
-    public Boolean isInverted() {
-        if(this.ctrl != null){
-            try {
-                return bbjSlider.getInverted();
-            } catch (BBjException e) {
-                Environment.logError(e);
-            }
-        }
-        return this.inverted;
     }
 
     /**
@@ -184,7 +170,7 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
 
     /**
      * This method returns the orientation of the ProgressBar control.
-     * @return Returns the orientation of the control (false = HORIZONTAL, true = VERTICAL).
+     * @return Returns the orientation of the control (false(0) = HORIZONTAL, true(1) = VERTICAL).
      */
     public Integer getOrientation() {
         if(this.ctrl != null){
@@ -254,23 +240,6 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             }
         }
         return this.value;
-    }
-
-    /**
-     * This method sets the orientation of the ProgressBar control. By default, the minimum value of a vertical slider is at the bottom and the maximum value is at the top. For a horizontal slider, the minimum value is to the left and the maximum value is to the right. The orientation reverses for inverted sliders.
-     * @param inverted - Specifies whether the slider orientation is inverted.
-     * @return Returns this
-     */
-    public Slider setInverted(Boolean inverted) {
-        if(this.ctrl != null){
-            try {
-                bbjSlider.setInverted(inverted);
-            } catch (BBjException e) {
-                Environment.logError(e);
-            }
-        }
-        this.inverted = inverted;
-        return this;
     }
 
     /**
@@ -573,11 +542,6 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             while(!this.callbacks.isEmpty()){
                 this.scrollEventSink.addCallback(this.callbacks.remove(0));
             }
-        }
-
-
-        if(Boolean.TRUE.equals(this.inverted)){
-            this.setInverted(this.inverted);
         }
 
         if(this.majorTickSpacing != 1){

--- a/src/main/java/org/dwcj/controls/slider/Slider.java
+++ b/src/main/java/org/dwcj/controls/slider/Slider.java
@@ -4,7 +4,6 @@ import com.basis.bbj.proxies.sysgui.BBjSlider;
 import com.basis.bbj.proxies.sysgui.BBjWindow;
 import com.basis.startup.type.BBjException;
 
-import org.dwcj.App;
 import org.dwcj.Environment;
 import org.dwcj.bridge.PanelAccessor;
 import org.dwcj.controls.AbstractDwcControl;
@@ -30,10 +29,21 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
         DEFAULT, DANGER, GRAY, INFO, SUCCESS, WARNING
     }
     
+    public enum Orientation{
+        HORIZONTAL("horizontal"), VERTICAL("vertical");
+
+        public final String orientation;
+
+        private Orientation(String orientation){
+            this.orientation = orientation;
+        }
+    }
+
     private ArrayList<Consumer<SliderOnControlScrollEvent>> callbacks = new ArrayList<>();
     private SliderOnControlScrollEventSink scrollEventSink;
     
-    private Boolean horizontal = true;
+    private Orientation orientation = Orientation.HORIZONTAL;
+    private Boolean inverted = false;
     private Integer majorTickSpacing = 1;
     private Integer minorTickSpacing = 1;
     private Integer maximum = 100;
@@ -45,11 +55,6 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
 
     
     public Slider(){
-        this(true);
-    }
-
-    public Slider(Boolean horizontal){ 
-        this.horizontal = horizontal; 
         this.focusable = true;
         this.mouseWheelCondition = MouseWheelCondition.DEFAULT;
         this.tabTraversable = true;
@@ -61,14 +66,9 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
         try {
             BBjWindow w = PanelAccessor.getDefault().getBBjWindow(p);
             byte [] flags = BBjFunctionalityHelper.buildStandardCreationFlags(this.isVisible(), this.isEnabled());
-            if (Boolean.TRUE.equals(horizontal)){
-                ctrl = w.addHorizontalSlider(w.getAvailableControlID(), BASISNUMBER_1, BASISNUMBER_1, BASISNUMBER_250, BASISNUMBER_250, flags);
-            }
-            else{
-                ctrl = w.addVerticalSlider(w.getAvailableControlID(), BASISNUMBER_1, BASISNUMBER_1, BASISNUMBER_250, BASISNUMBER_250, flags);
-            }
-                bbjSlider = (BBjSlider) ctrl;
-                catchUp();
+            ctrl = w.addHorizontalSlider(w.getAvailableControlID(), BASISNUMBER_1, BASISNUMBER_1, BASISNUMBER_250, BASISNUMBER_250, flags);
+            bbjSlider = (BBjSlider) ctrl;
+            catchUp();
         } catch (Exception e) {
             Environment.logError(e);
         }
@@ -91,6 +91,21 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             this.callbacks.add(callback);
         }
         return this;
+    }
+
+    /**
+     * This method gets the orientation of the ProgressBar control. By default, the minimum value of a vertical slider is at the bottom and the maximum value is at the top. For a horizontal slider, the minimum value is to the left and the maximum value is to the right. The orientation reverses for inverted sliders.
+     * @return Returns whether the control orientation is inverted.
+     */
+    public Boolean isInverted() {
+        if(this.ctrl != null){
+            try {
+                return bbjSlider.getInverted();
+            } catch (BBjException e) {
+                Environment.logError(e);
+            }
+        }
+        return this.inverted;
     }
 
     /**
@@ -170,13 +185,13 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
 
     /**
      * This method returns the orientation of the ProgressBar control.
-     * @return Returns the orientation of the control (false(0) = HORIZONTAL, true(1) = VERTICAL).
+     * @return Returns the orientation of the control (0 = HORIZONTAL, 1 = VERTICAL).
      */
     public Integer getOrientation() {
         if(this.ctrl != null){
             return bbjSlider.getOrientation();
         }
-        if(Boolean.TRUE.equals(this.horizontal)){
+        if(this.orientation == Orientation.HORIZONTAL){
             return 0;
         }
         return 1;
@@ -240,6 +255,23 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             }
         }
         return this.value;
+    }
+
+    /**
+     * This method sets the orientation of the ProgressBar control. By default, the minimum value of a vertical slider is at the bottom and the maximum value is at the top. For a horizontal slider, the minimum value is to the left and the maximum value is to the right. The orientation reverses for inverted sliders.
+     * @param inverted - Specifies whether the slider orientation is inverted.
+     * @return Returns this
+     */
+    public Slider setInverted(Boolean inverted) {
+        if(this.ctrl != null){
+            try {
+                bbjSlider.setInverted(inverted);
+            } catch (BBjException e) {
+                Environment.logError(e);
+            }
+        }
+        this.inverted = inverted;
+        return this;
     }
 
     /**
@@ -323,6 +355,19 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             }
         }
         this.minorTickSpacing = tick;
+        return this;
+    }
+
+    /**
+     * Will set the slider to vertical if the string "vertical" is passed. Defaults to horizontal for any other string.
+     * @param orientation String "vertical" to set the slider's orientation to vertical, "horizontal" for horizontal(default)
+     * @return The object itself
+     */
+    public Slider setOrientation(Orientation orientation){
+        if(this.ctrl != null){
+            this.setAttribute("orientation", orientation.orientation);
+        }
+        this.orientation=orientation;
         return this;
     }
 
@@ -467,7 +512,7 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
 
     @Override
     public Slider setText(String text) {
-        //does nothing for this control
+        super.setText(text);
         return this;
     }
 
@@ -544,6 +589,11 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             }
         }
 
+
+        if(Boolean.TRUE.equals(this.inverted)){
+            this.setInverted(this.inverted);
+        }
+
         if(this.majorTickSpacing != 1){
             this.setMajorTickSpacing(this.majorTickSpacing);
         }
@@ -576,7 +626,9 @@ public final class Slider extends AbstractDwcControl implements Focusable, HasMo
             this.setValue(this.value);
         }
 
-
+        if(this.orientation != Orientation.HORIZONTAL){
+            this.setOrientation(Orientation.VERTICAL);
+        }
 
         if(Boolean.FALSE.equals(this.focusable)){
             this.setFocusable(this.focusable);


### PR DESCRIPTION
Removed the inverted functionality as this seemed to be ineffective in DWCJ, and removed the functionality from setText, though the function still shows up in IDE autocompletion as it's in AbstractDwcControl.
