### PR TITLE
add most basic methods to handle DIV panels inside a tab control

### DIFF
--- a/src/main/java/org/dwcj/controls/tabcontrol/TabControl.java
+++ b/src/main/java/org/dwcj/controls/tabcontrol/TabControl.java
@@ -120,6 +120,11 @@ public final class TabControl extends AbstractDwcControl {
         return this;
     }
 
+    /**
+     * Add a tab to the tab control
+     * @param text the text to display on the tab control
+     * @return
+     */
     public TabControl addTab(String text){
         try {
             this.tabCtrl.addTab(text,-1);
@@ -128,6 +133,39 @@ public final class TabControl extends AbstractDwcControl {
         }
         return this;
     }
+
+    /**
+     * Add a tab and add a Div to it.
+     * Important: The DIV has to exist on the parent panel, you need to call "add" before passing it to the tab control.
+     * @param text The text for the tab
+     * @param panel the panel to attach to the tab
+     * @return the Tab Control object
+     */
+    public TabControl addTab(String text, Div panel) {
+        try {
+            this.tabCtrl.addTab(text,PanelAccessor.getDefault().getBBjWindow(panel));
+        } catch (BBjException | IllegalAccessException e) {
+            Environment.logError(e);
+        }
+        return this;
+    }
+
+    /**
+     * Put a DIV under an existing tab
+     * Important: The DIV has to exist on the parent panel, you need to call "add" before passing it to the tab control.
+     * @param index the zero-based index of the tab
+     * @param panel the DIV panel to put under the tab
+     * @return the Tab Control object itself
+     */
+    public TabControl setPanelAt(int index, Div panel) {
+        try {
+            this.tabCtrl.setControlAt(index, PanelAccessor.getDefault().getBBjWindow(panel));
+        } catch (BBjException | IllegalAccessException e) {
+            Environment.logError(e);
+        }
+        return this;
+    }
+
 
     /**
      * register an event callback for the click event


### PR DESCRIPTION
This implements the most basic Tab Control handling methods to put a DIV under a tab.

There seems to be a problem though which I had noticed in BBj already: When adding a ChildWindow to a tab, DWC or BBj seems to destroy the "display" style of the ChildWindow that's added. See this sample:

```java
package fiddle;

import org.dwcj.App;
import org.dwcj.controls.button.Button;
import org.dwcj.controls.label.Label;
import org.dwcj.controls.panels.AppPanel;
import org.dwcj.controls.panels.Div;
import org.dwcj.controls.tabcontrol.TabControl;
import org.dwcj.exceptions.DwcException;

public class TabControlSample extends App {

    @Override
    public void run() throws DwcException {
        AppPanel p = new AppPanel();
        TabControl tab = new TabControl();
        p.add(tab);

        // add div immediately
        Div panel1 = new Div();
        p.add(panel1);
        panel1.add(new Label("Hi There Tab 1"));
        panel1.add(new Button("Button on Tab 1"));
        panel1.setStyle("display","grid");
        panel1.setStyle("padding","30px");

        tab.addTab("Tab 1", panel1);

        // add div later
        tab.addTab("Tab 2");
        Div panel2 = new Div();
        p.add(panel2);
        panel2.add(new Label("Hi There Tab 2"));
        panel2.add(new Button("Button on Tab 2"));
        panel2.setStyle("display","grid");
        panel2.setStyle("padding","30px");
        tab.setPanelAt(1,panel2);

        // why does "display" get lost if set before adding the tab?
        panel1.setStyle("display","grid");
        panel2.setStyle("display","grid");

    }
}
```

If the "setStyle" is not repeated at the end, the "display" will not be set to "grid". @hyyan  can you check this in DWC please?