### PR TITLE
Fixed #150 - Fix WARNING in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
     </dependencies>
 
     <build>
-        <finalName>dwcj-${version}</finalName>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
 - removed the configuration for finalName because the version is already given by default behaviour.