### PR TITLE
refactor: intrdouce context and webserver protocols

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/Page.java
+++ b/dwcj-engine/src/main/java/org/dwcj/Page.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.dwcj.exceptions.DwcException;
 import org.dwcj.exceptions.DwcRuntimeException;
+import org.dwcj.util.Assets;
 
 import com.basis.startup.type.BBjException;
 
@@ -219,7 +220,11 @@ public final class Page {
    */
   public Page addStyleSheet(String url, boolean top, Map<String, String> attributes) {
     try {
-      Environment.getInstance().getBBjAPI().getWebManager().injectStyleUrl(url, top, attributes);
+      if (Assets.isWebServerURL(url))
+        url = Assets.resolveWebServerURL(url);
+
+      Environment.getInstance().getBBjAPI().getWebManager().injectStyleUrl(
+          url, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add stylesheet.", e); // NOSONAR
     }
@@ -239,7 +244,11 @@ public final class Page {
    */
   public Page addStyleSheet(String url, boolean top, String attributes) {
     try {
-      Environment.getInstance().getBBjAPI().getWebManager().injectStyleUrl(url, top, attributes);
+      if (Assets.isWebServerURL(url))
+        url = Assets.resolveWebServerURL(url);
+
+      Environment.getInstance().getBBjAPI().getWebManager().injectStyleUrl(
+          url, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add stylesheet.", e); // NOSONAR
     }
@@ -284,6 +293,9 @@ public final class Page {
    */
   public Page addInlineStyleSheet(String css, boolean top, Map<String, String> attributes) {
     try {
+      if (Assets.isContextURL(css))
+        css = Assets.contentOf(Assets.resolveContextURL(css));
+
       Environment.getInstance().getBBjAPI().getWebManager().injectStyle(css, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add inline stylesheet.", e); // NOSONAR
@@ -304,6 +316,9 @@ public final class Page {
    */
   public Page addInlineStyleSheet(String css, boolean top, String attributes) {
     try {
+      if (Assets.isContextURL(css))
+        css = Assets.contentOf(Assets.resolveContextURL(css));
+
       Environment.getInstance().getBBjAPI().getWebManager().injectStyle(css, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add inline stylesheet.", e); // NOSONAR
@@ -350,6 +365,9 @@ public final class Page {
    */
   public Page addJavaScript(String url, boolean top, Map<String, String> attributes) {
     try {
+      if (Assets.isWebServerURL(url))
+        url = Assets.resolveWebServerURL(url);
+
       Environment.getInstance().getBBjAPI().getWebManager().injectScriptUrl(url, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add script.", e); // NOSONAR
@@ -370,6 +388,9 @@ public final class Page {
    */
   public Page addJavaScript(String url, boolean top, String attributes) {
     try {
+      if (Assets.isWebServerURL(url))
+        url = Assets.resolveWebServerURL(url);
+
       Environment.getInstance().getBBjAPI().getWebManager().injectScriptUrl(url, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add script.", e); // NOSONAR
@@ -416,6 +437,9 @@ public final class Page {
    */
   public Page addInlineJavaScript(String script, boolean top, Map<String, String> attributes) {
     try {
+      if (Assets.isContextURL(script))
+        script = Assets.contentOf(Assets.resolveContextURL(script));
+
       Environment.getInstance().getBBjAPI().getWebManager().injectScript(script, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add inline script.", e); // NOSONAR
@@ -436,6 +460,9 @@ public final class Page {
    */
   public Page addInlineJavaScript(String script, boolean top, String attributes) {
     try {
+      if (Assets.isContextURL(script))
+        script = Assets.contentOf(Assets.resolveContextURL(script));
+
       Environment.getInstance().getBBjAPI().getWebManager().injectScript(script, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add inline script.", e); // NOSONAR
@@ -481,6 +508,9 @@ public final class Page {
    */
   public Page addLink(String url, boolean top, Map<String, String> attributes) {
     try {
+      if (Assets.isWebServerURL(url))
+        url = Assets.resolveWebServerURL(url);
+
       Environment.getInstance().getBBjAPI().getWebManager().injectLinkUrl(url, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add link.", e); // NOSONAR
@@ -501,6 +531,9 @@ public final class Page {
    */
   public Page addLink(String url, boolean top, String attributes) {
     try {
+      if (Assets.isWebServerURL(url))
+        url = Assets.resolveWebServerURL(url);
+
       Environment.getInstance().getBBjAPI().getWebManager().injectLinkUrl(url, top, attributes);
     } catch (BBjException e) {
       throw new DwcRuntimeException("Failed to add link.", e); // NOSONAR

--- a/dwcj-engine/src/main/java/org/dwcj/Page.java
+++ b/dwcj-engine/src/main/java/org/dwcj/Page.java
@@ -211,7 +211,9 @@ public final class Page {
   /**
    * Inject a stylesheet into the page
    *
-   * @param url        The URL of the stylesheet
+   * @param url        The URL of the stylesheet. The url will be resolved
+   *                   as a web server url if it starts with the
+   *                   <code>webserver://</code>
    * @param top        Whether to inject the stylesheet at the top of the page
    * @param attributes A map of attributes to set
    * 
@@ -235,7 +237,9 @@ public final class Page {
   /**
    * Inject a stylesheet into the page
    *
-   * @param url        The URL of the stylesheet
+   * @param url        The URL of the stylesheet. The url will be resolved
+   *                   as a web server url if it starts with the
+   *                   <code>webserver://</code>
    * @param top        Whether to inject the stylesheet at the top of the page
    * @param attributes A map of attributes to set (comma separated)
    * 
@@ -259,7 +263,9 @@ public final class Page {
   /**
    * Inject a stylesheet into the page
    *
-   * @param url The URL of the stylesheet
+   * @param url The URL of the stylesheet. The url will be resolved
+   *            as a web server url if it starts with the
+   *            <code>webserver://</code>
    * @param top Whether to inject the stylesheet at the top of the page
    * 
    * @return The current page instance
@@ -272,7 +278,9 @@ public final class Page {
   /**
    * Inject a stylesheet into the page
    *
-   * @param url The URL of the stylesheet
+   * @param url The URL of the stylesheet. The url will be resolved
+   *            as a web server url if it starts with the
+   *            <code>webserver://</code>
    * 
    * @return The current page instance
    * @throws DwcRuntimeException if failed to add the stylesheet
@@ -284,7 +292,10 @@ public final class Page {
   /**
    * Inject an inline stylesheet into the page
    *
-   * @param css        The CSS to inject
+   * @param css        The CSS to inject. If a url is provided and starts with
+   *                   <code>context://</code> then the url will be resolved
+   *                   as a context url which points to the root of the
+   *                   resources folder of your application
    * @param top        Whether to inject the stylesheet at the top of the page
    * @param attributes A map of attributes to set
    * 
@@ -307,7 +318,10 @@ public final class Page {
   /**
    * Inject an inline stylesheet into the page
    *
-   * @param css        The CSS to inject
+   * @param css        The CSS to inject. If a url is provided and starts with
+   *                   <code>context://</code> then the url will be resolved
+   *                   as a context url which points to the root of the
+   *                   resources folder of your application
    * @param top        Whether to inject the stylesheet at the top of the page
    * @param attributes A map of attributes to set (comma separated)
    * 
@@ -330,7 +344,10 @@ public final class Page {
   /**
    * Inject an inline stylesheet into the page
    *
-   * @param css The CSS to inject
+   * @param css The CSS to inject. If a url is provided and starts with
+   *            <code>context://</code> then the url will be resolved
+   *            as a context url which points to the root of the
+   *            resources folder of your application
    * @param top Whether to inject the stylesheet at the top of the page
    * 
    * @return The current page instance
@@ -343,7 +360,10 @@ public final class Page {
   /**
    * Inject an inline stylesheet into the page
    *
-   * @param css The CSS to inject
+   * @param css The CSS to inject. If a url is provided and starts with
+   *            <code>context://</code> then the url will be resolved
+   *            as a context url which points to the root of the
+   *            resources folder of your application
    * 
    * @return The current page instance
    * @throws DwcRuntimeException if failed to add the stylesheet
@@ -356,7 +376,9 @@ public final class Page {
   /**
    * Inject a script into the page
    *
-   * @param url        The URL of the script
+   * @param url        The URL of the script. The url will be resolved
+   *                   as a web server url if it starts with the
+   *                   <code>webserver://</code>
    * @param top        Whether to inject the script at the top of the page
    * @param attributes A map of attributes to set
    * 
@@ -379,7 +401,9 @@ public final class Page {
   /**
    * Inject a script into the page
    *
-   * @param url        The URL of the script
+   * @param url        The URL of the script. The url will be resolved
+   *                   as a web server url if it starts with the
+   *                   <code>webserver://</code>
    * @param top        Whether to inject the script at the top of the page
    * @param attributes A map of attributes to set (comma separated)
    * 
@@ -402,7 +426,9 @@ public final class Page {
   /**
    * Inject a script into the page
    *
-   * @param url The URL of the script
+   * @param url The URL of the script.The url will be resolved
+   *            as a web server url if it starts with the
+   *            <code>webserver://</code>
    * @param top Whether to inject the script at the top of the page
    * 
    * @return The current page instance
@@ -416,7 +442,9 @@ public final class Page {
   /**
    * Inject a script into the page
    *
-   * @param url The URL of the script
+   * @param url The URL of the script. The url will be resolved
+   *            as a web server url if it starts with the
+   *            <code>webserver://</code>
    * 
    * @return The current page instance
    * @throws DwcRuntimeException if failed to add the script
@@ -428,7 +456,10 @@ public final class Page {
   /**
    * Inject an inline script into the page
    *
-   * @param script     The script to inject
+   * @param script     The script to inject. If a url is provided and starts with
+   *                   <code>context://</code> then the url will be resolved
+   *                   as a context url which points to the root of the
+   *                   resources folder of your application
    * @param top        Whether to inject the script at the top of the page
    * @param attributes A map of attributes to set
    * 
@@ -451,7 +482,10 @@ public final class Page {
   /**
    * Inject an inline script into the page
    *
-   * @param script     The script to inject
+   * @param script     The script to inject. If a url is provided and starts with
+   *                   <code>context://</code> then the url will be resolved
+   *                   as a context url which points to the root of the
+   *                   resources folder of your application
    * @param top        Whether to inject the script at the top of the page
    * @param attributes A map of attributes to set (comma separated)
    * 
@@ -474,7 +508,10 @@ public final class Page {
   /**
    * Inject an inline script into the page
    *
-   * @param script The script to inject
+   * @param script The script to inject. If a url is provided and starts with
+   *               <code>context://</code> then the url will be resolved
+   *               as a context url which points to the root of the
+   *               resources folder of your application
    * @param top    Whether to inject the script at the top of the page
    * 
    * @return The current page instance
@@ -487,7 +524,10 @@ public final class Page {
   /**
    * Inject an inline script into the page
    *
-   * @param script The script to inject
+   * @param script The script to inject. If a url is provided and starts with
+   *               <code>context://</code> then the url will be resolved
+   *               as a context url which points to the root of the
+   *               resources folder of your application
    * 
    * @return The current page instance
    * @throws DwcRuntimeException if failed to add the script
@@ -499,7 +539,9 @@ public final class Page {
   /**
    * Inject a link into the page
    *
-   * @param url        The URL of the link
+   * @param url        The URL of the link. The url will be resolved
+   *                   as a web server url if it starts with the
+   *                   <code>webserver://</code>
    * @param top        Whether to inject the link at the top of the page
    * @param attributes A map of attributes to set
    * 
@@ -522,7 +564,9 @@ public final class Page {
   /**
    * Inject a link into the page
    *
-   * @param url        The URL of the link
+   * @param url        The URL of the link. The url will be resolved
+   *                   as a web server url if it starts with the
+   *                   <code>webserver://</code>
    * @param top        Whether to inject the link at the top of the page
    * @param attributes A map of attributes to set (comma separated)
    * 
@@ -545,7 +589,9 @@ public final class Page {
   /**
    * Inject a link into the page
    *
-   * @param url The URL of the link
+   * @param url The URL of the link. The url will be resolved
+   *            as a web server url if it starts with the
+   *            <code>webserver://</code>
    * @param top Whether to inject the link at the top of the page
    * 
    * @return The current page instance
@@ -558,7 +604,9 @@ public final class Page {
   /**
    * Inject a link into the page
    *
-   * @param url The URL of the link
+   * @param url The URL of the link.The url will be resolved
+   *            as a web server url if it starts with the
+   *            <code>webserver://</code>
    * 
    * @return The current page instance
    * @throws DwcRuntimeException if failed to add the link

--- a/dwcj-engine/src/main/java/org/dwcj/annotations/AnnotationProcessor.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/AnnotationProcessor.java
@@ -6,7 +6,6 @@ import org.dwcj.controls.AbstractControl;
 import org.dwcj.environment.ObjectTable;
 import org.dwcj.exceptions.DwcAnnotationException;
 import org.dwcj.exceptions.DwcException;
-import org.dwcj.util.Assets;
 
 /**
  * Annotation processor for the application and controls annotations
@@ -181,7 +180,7 @@ public final class AnnotationProcessor {
           attributes.put(attribute.name(), attribute.value());
         }
 
-        String key = "org.dwcj.annotations.AnnotationProcessor::styles::" + sheet.url();
+        String key = "org.dwcj.annotations.AnnotationProcessor::styles::" + sheet.value();
         if (sheet.top()) {
           key += "::top";
         }
@@ -191,7 +190,7 @@ public final class AnnotationProcessor {
         }
 
         ObjectTable.put(key, true);
-        App.getPage().addStyleSheet(sheet.url(), sheet.top(), attributes);
+        App.getPage().addStyleSheet(sheet.value(), sheet.top(), attributes);
       }
     }
   }
@@ -227,12 +226,7 @@ public final class AnnotationProcessor {
           }
         }
 
-        String content = sheet.value();
-        if (sheet.local()) {
-          content = Assets.contentOf(content);
-        }
-
-        App.getPage().addInlineStyleSheet(content, sheet.top(), attributes);
+        App.getPage().addInlineStyleSheet(sheet.value(), sheet.top(), attributes);
       }
     }
   }
@@ -252,7 +246,7 @@ public final class AnnotationProcessor {
           attributes.put(attribute.name(), attribute.value());
         }
 
-        String key = "org.dwcj.annotations.AnnotationProcessor::scripts::" + script.url();
+        String key = "org.dwcj.annotations.AnnotationProcessor::scripts::" + script.value();
         if (script.top()) {
           key += "::top";
         }
@@ -262,7 +256,7 @@ public final class AnnotationProcessor {
         }
 
         ObjectTable.put(key, true);
-        App.getPage().addJavaScript(script.url(), script.top(), attributes);
+        App.getPage().addJavaScript(script.value(), script.top(), attributes);
       }
     }
   }
@@ -295,12 +289,7 @@ public final class AnnotationProcessor {
           ObjectTable.put(key, true);
         }
 
-        String content = script.value();
-        if (script.local()) {
-          content = Assets.contentOf(content);
-        }
-
-        App.getPage().addInlineJavaScript(content, script.top(), attributes);
+        App.getPage().addInlineJavaScript(script.value(), script.top(), attributes);
       }
     }
   }

--- a/dwcj-engine/src/main/java/org/dwcj/annotations/InlineJavaScript.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/InlineJavaScript.java
@@ -54,14 +54,6 @@ public @interface InlineJavaScript {
   boolean top() default false;
 
   /**
-   * A boolean value specifying whether this script is to be injected is in local
-   * file.
-   * 
-   * @return true if the script is to be injected is in local file
-   */
-  boolean local() default false;
-
-  /**
    * A set of <a href=
    * "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script">attributes</a>
    * to be added to the script element.

--- a/dwcj-engine/src/main/java/org/dwcj/annotations/InlineStyleSheet.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/InlineStyleSheet.java
@@ -52,14 +52,6 @@ public @interface InlineStyleSheet {
   String value();
 
   /**
-   * A boolean value specifying whether this style is to be injected is in a local
-   * file.
-   * 
-   * @return true if the style is to be injected is in local file
-   */
-  boolean local() default false;
-
-  /**
    * A boolean value specifying whether this style is to be injected into the top
    * level window of the page.
    * 

--- a/dwcj-engine/src/main/java/org/dwcj/annotations/JavaScript.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/JavaScript.java
@@ -34,7 +34,7 @@ public @interface JavaScript {
    * 
    * @return the JavaScript URL
    **/
-  String url();
+  String value();
 
   /**
    * A boolean value specifying whether this script is to be injected into the top

--- a/dwcj-engine/src/main/java/org/dwcj/annotations/StyleSheet.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/StyleSheet.java
@@ -34,7 +34,7 @@ public @interface StyleSheet {
    * 
    * @return the CSS URL
    **/
-  String url();
+  String value();
 
   /**
    * A boolean value specifying whether this style is to be injected into the top

--- a/dwcj-engine/src/main/java/org/dwcj/util/Assets.java
+++ b/dwcj-engine/src/main/java/org/dwcj/util/Assets.java
@@ -6,10 +6,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
+import org.dwcj.App;
 import org.dwcj.Environment;
+import org.dwcj.bridge.IDwcjBBjBridge;
+import org.dwcj.exceptions.DwcRuntimeException;
 
 /**
- * A helper class to deal with assets in the classpath
+ * A helper class to deal with assets in the class path
  * 
  * @author Hyyan Abo Fakher
  */
@@ -23,6 +26,10 @@ public class Assets {
    * 
    * @param path The path to the resource
    * @return The content of the resource as a String
+   * 
+   * @throws IllegalArgumentException if the path is null or empty
+   * @throws DwcRuntimeException      if an error occurred while reading the
+   *                                  resource
    */
   public static String contentOf(String path) {
     ClassLoader classLoader = Environment.getInstance().getClass().getClassLoader();
@@ -35,7 +42,82 @@ public class Assets {
         return reader.lines().collect(Collectors.joining(System.lineSeparator()));
       }
     } catch (IOException e) {
-      throw new RuntimeException(e); // NOSONAR
+      throw new DwcRuntimeException(e); // NOSONAR
     }
+  }
+
+  /**
+   * Get the URL of the Jetty Web Server's files directory.
+   * 
+   * @return The URL of the Jetty Web Server's files directory.
+   */
+  public static String getWebServerFilesUrl() {
+    IDwcjBBjBridge helper = Environment.getInstance().getDwcjHelper();
+    Object instance = helper.createInstance("::BBUtils.bbj::BBUtils");
+
+    return (String) helper.invokeMethod(instance, "getWebServerFilesURL", null);
+  }
+
+  /**
+   * Check if the given url starts with the <code>webserver://</code> protocol or
+   * not.
+   * 
+   * For example:
+   * <code>webserver://static/css/foo.css</code> will return true
+   * <code>http://example.com/static/css/foo.css</code> will return false
+   * 
+   * @param url The url
+   * @return true if the url is an jetty url, false otherwise
+   */
+  public static boolean isWebServerURL(String url) {
+    return url.toLowerCase().startsWith("webserver://");
+  }
+
+  /**
+   * Get the url from the given webserver url.
+   * 
+   * For example:
+   * <code>webserver://static/css/foo.css</code> will return
+   * <code>${APP_URL}/files/${APP_NAME}/static/css/foo.css</code>
+   * <code>http://example.com/static/css/foo.css</code> will throw an
+   * IllegalArgumentException
+   * 
+   * @param url The url
+   * @throws IllegalArgumentException if the url is not a webserver url
+   */
+  public static String resolveWebServerURL(String url) {
+    if (!isWebServerURL(url))
+      throw new IllegalArgumentException("URL does not being the \"webserver://\" protocol: " + url);
+
+    String fullURL = getWebServerFilesUrl() +
+        App.getApplicationName() + "/" +
+        url.toLowerCase().replace("webserver://", "").trim();
+
+    return fullURL.replaceAll("(?<!\\w+:/?)//+", "/");
+  }
+
+  /**
+   * Check if the given url is an local url or not
+   * 
+   * @param url The url
+   * @return true if the url is an local url, false otherwise
+   */
+  public static boolean isContextURL(String url) {
+    return url.toLowerCase().startsWith("context://");
+  }
+
+  /**
+   * Get the url from the given local url
+   * 
+   * @param url The url
+   * 
+   * @return The url
+   * @throws IllegalArgumentException if the url is not an local url
+   */
+  public static String resolveContextURL(String url) {
+    if (!isContextURL(url))
+      throw new IllegalArgumentException("URL does not being the \"context://\" protocol: " + url);
+
+    return url.toLowerCase().replace("context://", "").trim();
   }
 }


### PR DESCRIPTION
@mhawkinsbasis 

The PR is to improve assets managing.

1. `addStyleSheet`, `addJavaScript` and `addLink` supports now the `webserver://` protocol. 
For instance:

``` java
addStyleSheet('webserver://static/css/style.css');
``` 
In this case the URL points to the folder of the running application under jetty's htdocs (`bbx/htdocs/myapp`). 

2. `addInlineStyleSheet` & `addInlineJavaScript` supports now the `context://` protocol. 
For instance:

```java
addInlineJavaScript('"context://public/js/jquery.js"');
```
In this case the URL points to the root of the `resources` folder of your application.

3. `InlineStyleSheet` & `InlineJavaScript` annotations do not support the `local` attribute anymore. Use the `context://` protocol. 
4. `StyleSheet` & `JavaScript` annotations rename `url` attribute to `value`:

instead of 
```java 
@StyleSheet(url = "https://www.w3schools.com/w3css/4/w3.css")
```
Use 
```java
@StyleSheet("https://www.w3schools.com/w3css/4/w3.css")
// or 
@StyleSheet(value="https://www.w3schools.com/w3css/4/w3.css")
```