### PR TITLE
Fixed implementation of catchup in abstractDwcControl to only add ite…

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/controls/AbstractDwcControl.java
+++ b/dwcj-engine/src/main/java/org/dwcj/controls/AbstractDwcControl.java
@@ -101,8 +101,9 @@ public abstract class AbstractDwcControl extends AbstractControl implements HasA
             ctrl.setAttribute(attribute, value);
         } catch (BBjException e) {
             Environment.logError(e);
+        } else{
+            attributes.put(attribute, value);
         }
-        attributes.put(attribute, value);
         return this;
     }
 
@@ -174,8 +175,9 @@ public abstract class AbstractDwcControl extends AbstractControl implements HasA
             ctrl.setStyle(property, value);
         } catch (BBjException e) {
             Environment.logError(e);
+        } else{
+            this.styles.put(property, value);
         }
-        this.styles.put(property, value);
         return this;
     }
 


### PR DESCRIPTION
…ms to catchup arrays if control is not added to panel