### PR TITLE
feat: adds the `STConfiuration` annotation

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/annotations/STConfiuration.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/STConfiuration.java
@@ -9,8 +9,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation to define the configuration to manipulate the global
- * {@link org.dwcj.environment.StringTable}. 
+ * An annotation to manipulate the global
+ * {@link org.dwcj.environment.StringTable}.
  * 
  * <p>
  * The configuration is a key/value pair that will be passed to the global

--- a/dwcj-engine/src/main/java/org/dwcj/annotations/STConfiuration.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/STConfiuration.java
@@ -1,0 +1,73 @@
+package org.dwcj.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to define the configuration of the {@link org.dwcj.core.DWCJ}
+ * 
+ * <p>
+ * The configuration is a key/value pair that will be passed to the global
+ * {@link org.dwcj.environment.StringTable}.
+ * </p>
+ * 
+ * <p>
+ * This annotation can be used multiple times to define multiple configuration
+ * and it can be used at the Application or the controls level. But application
+ * level configurations will override the controls level configurations.
+ * </p>
+ * 
+ * <pre>
+ * {@code
+ *  &#64;Configuration(key = "DEBUG", value = "1")
+ * }
+ * </pre>
+ * 
+ * @see org.dwcj.environment.StringTable
+ * 
+ * @author Hyyan Abo Fakher
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(STConfiuration.Container.class)
+@Inherited
+@Documented
+public @interface STConfiuration {
+  /**
+   * The configuration key
+   * 
+   * @return the configuration key
+   */
+  String key();
+
+  /**
+   * The configuration value
+   * 
+   * @return the configuration value
+   **/
+  String value();
+
+  /**
+   * A container for the {@link STConfiuration} annotation
+   * 
+   * @see STConfiuration
+   * @author Hyyan Abo Fakher
+   */
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Inherited
+  @Documented
+  public @interface Container {
+    /**
+     * A container for the {@link STConfiuration} annotation
+     * 
+     * @return the {@link STConfiuration} annotations
+     */
+    STConfiuration[] value();
+  }
+}

--- a/dwcj-engine/src/main/java/org/dwcj/annotations/STConfiuration.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotations/STConfiuration.java
@@ -9,7 +9,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation to define the configuration of the {@link org.dwcj.core.DWCJ}
+ * An annotation to define the configuration to manipulate the global
+ * {@link org.dwcj.environment.StringTable}. 
  * 
  * <p>
  * The configuration is a key/value pair that will be passed to the global

--- a/dwcj-engine/src/main/java/org/dwcj/environment/StringTable.java
+++ b/dwcj-engine/src/main/java/org/dwcj/environment/StringTable.java
@@ -8,16 +8,16 @@ import java.util.NoSuchElementException;
 /**
  * Provides access to the STBL String Table.
  * 
- * The TBL String Table is persistent, and global scope in this thread
+ * The STBL String Table is persistent, and global scope in this thread
  * Values can be changed programmatically or set in the config file, e.g.:
  * 
  * <pre>
  * SET COMPANY=Acme
  * </pre>
  * 
- * . Then you can access the value with
+ * Then you can access the value with
  * 
- * {@code String val = org.dwcj.environment.StringTable.get("COMPANY")}
+ * {@code String val = StringTable.get("COMPANY")}
  */
 public final class StringTable {
 
@@ -25,6 +25,21 @@ public final class StringTable {
    * private constructor to prevent instantiation
    */
   private StringTable() {
+  }
+
+  /**
+   * Checks if the string table contains a key
+   * 
+   * @param key the key of the variable to check
+   * @return true if the string table contains the key
+   */
+  public static boolean contains(String key) {
+    try {
+      StringTable.get(key);
+      return true;
+    } catch (NoSuchElementException e) {
+      return false;
+    }
   }
 
   /**

--- a/dwcj-engine/src/main/resources/bbj/dwcj.bbj
+++ b/dwcj-engine/src/main/resources/bbj/dwcj.bbj
@@ -11,20 +11,13 @@ SETERR dwcj_error
 BBJAPI().getConfig().releaseOnLostConnection(0)
 
 DEBUG = 0
-DEBUG=NUM(STBL("DEBUG",err=*next),err=*next)
-
 dummy$=STBL("!OPTIONS","ERROR_UNWINDS=true")
-
+gosub checkDebugMode
 
 class$=""
 
 rem evaluate arguments
 for i=1 to 10
-    tmp$=argv(i,err=*break)
-    if cvs(tmp$,4)="DEBUG" then
-        DEBUG=1
-        continue
-    fi
     if len(tmp$)>6 and tmp$(1,6)="class=" then
         class$=tmp$(7)
         continue
@@ -55,6 +48,19 @@ process_events,err=dwcj_error
 terminate:
     release
     
+
+checkDebugMode:
+  DEBUG=NUM(STBL("DEBUG",err=*next),err=*next)
+
+  rem evaluate arguments
+  for i=1 to 10
+      tmp$=argv(i,err=*break)
+      if cvs(tmp$,4)="DEBUG" then
+          DEBUG=1
+          continue
+      fi
+  next
+return  
 
 determineClasspathEntries:
         admin! = new Admin()
@@ -110,6 +116,8 @@ class_not_found:
 release
 
 dwcj_error:
+    gosub checkDebugMode
+    
     if DEBUG=0 then
         a=msgbox("An error has occured!",48,"Error")
     else


### PR DESCRIPTION
The PR adds the `STConfiuration` annotation:

The `STConfiuration` is an annotation to manipulate the global [`StringTable`](https://github.com/DwcJava/engine/blob/main/dwcj-engine/src/main/java/org/dwcj/environment/StringTable.java).

This annotation can be used multiple times to define multiple configuration and it can be used at the Application or the controls level. Application level configurations will always override the controls level configurations.

Certain configurations cannot be overridden at the application level when they are defined in the `config.bbx` file. Like `DEBUG` flag

The annotation will guarantee the order of which the configuration are applied unlike using the  [`StringTable`](https://github.com/DwcJava/engine/blob/main/dwcj-engine/src/main/java/org/dwcj/environment/StringTable.java) directly 

### Sample

```java
// HelloWorldComponent.java

import org.dwcj.annotations.STConfiuration;
import org.dwcj.controls.AbstractControl;
import org.dwcj.controls.label.Label;
import org.dwcj.controls.panels.AbstractPanel;
import org.dwcj.environment.StringTable;

@STConfiuration(key = "my-configuration", value = "Hello World")
public class HelloWorldComponent extends AbstractControl {

  @Override
  protected void create(AbstractPanel panel) {
    panel.add(new Label(
        String.format("<html><h1>%s</h1></html>", StringTable.get("my-configuration"))));
  }
}
```

```java
// Application.java

import org.dwcj.App;
import org.dwcj.annotations.STConfiuration;
import org.dwcj.controls.panels.AppPanel;
import org.dwcj.exceptions.DwcException;

@STConfiuration(key = "DEBUG", value = "1")
@STConfiuration(key = "my-configuration", value = "Hello DWCJ")
public class Application extends App {

  @Override
  public void run() throws DwcException {
    AppPanel panel = new AppPanel();
    panel.add(new HelloWorldComponent());
  }
}
```
