### PR TITLE
feat: add restricted properties an attributes API 

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/component/AbstractDwcComponent.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/AbstractDwcComponent.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import javax.swing.JOptionPane;
 import org.dwcj.Environment;
 import org.dwcj.exceptions.DwcjRestrictedAccessException;
 import org.dwcj.exceptions.DwcjRuntimeException;
@@ -48,10 +47,10 @@ public abstract class AbstractDwcComponent extends AbstractComponent implements 
   private final List<String> removeStyles = new ArrayList<>();
   private final List<String> cssClasses = new ArrayList<>();
   private final List<String> removeCssClasses = new ArrayList<>();
-  private final Map<String, String> attributes = new ConcurrentHashMap<>();
-  private final Map<String, Object> properties = new HashMap<>();
   private Enum<?> theme = null;
   private Enum<?> expanse = null;
+  private final Map<String, String> attributes = new ConcurrentHashMap<>();
+  private final Map<String, Object> properties = new ConcurrentHashMap<>();
   private Enum<? extends ExpanseBase> componentExpanse = null;
 
   /**
@@ -67,7 +66,8 @@ public abstract class AbstractDwcComponent extends AbstractComponent implements 
   public AbstractDwcComponent setProperty(String property, Object value) {
     List<String> restrictedProperties = getRestrictedProperties();
     if (!restrictedProperties.isEmpty() && restrictedProperties.contains(property)) {
-      throw new DwcjRestrictedAccessException("Property " + property + " is restricted.");
+      throw new DwcjRestrictedAccessException(
+          "The property '" + property + "' is restricted and cannot be modified.");
     }
 
     return setUnrestrictedProperty(property, value);
@@ -85,9 +85,10 @@ public abstract class AbstractDwcComponent extends AbstractComponent implements 
       try {
         return control.getClientProperty(property);
       } catch (BBjException e) {
-        Environment.logError(e);
+        throw new DwcjRuntimeException(e);
       }
     }
+
     return properties.get(property);
   }
 
@@ -136,19 +137,18 @@ public abstract class AbstractDwcComponent extends AbstractComponent implements 
     List<String> restrictedProperties = getRestrictedProperties();
 
     if (!restrictedProperties.isEmpty()) {
-      // Attribute names with dashes are converted to camelCase property names by capitalizing
-      // (except first word) the
+      // Attribute names with dashes are converted to camelCase property names by capitalizing the
       // character following each dash, then removing the dashes. For example, the attribute
       // first-name maps to firstName. The same mappings happen in reverse when converting property
       // names to attribute names
       String property = Arrays.stream(attribute.split("-"))
           .map(word -> word.substring(0, 1).toUpperCase() + word.substring(1))
           .collect(Collectors.joining());
-
-      // JOptionPane.showMessageDialog(null, property, "Message", JOptionPane.INFORMATION_MESSAGE);
+      property = property.substring(0, 1).toLowerCase() + property.substring(1);
 
       if (restrictedProperties.contains(property)) {
-        throw new DwcjRestrictedAccessException("Attribute " + attribute + " is restricted.");
+        throw new DwcjRestrictedAccessException(
+            "The attribute " + attribute + " is restricted and cannot be modified.");
       }
     }
 
@@ -515,9 +515,9 @@ public abstract class AbstractDwcComponent extends AbstractComponent implements 
       } catch (BBjException e) {
         throw new DwcjRuntimeException(e);
       }
-    } else {
-      properties.put(property, value);
     }
+
+    properties.put(property, value);
     return this;
   }
 

--- a/dwcj-engine/src/main/java/org/dwcj/component/checkbox/CheckBox.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/checkbox/CheckBox.java
@@ -2,6 +2,8 @@ package org.dwcj.component.checkbox;
 
 import com.basis.bbj.proxies.sysgui.BBjWindow;
 import com.basis.startup.type.BBjException;
+import java.util.Arrays;
+import java.util.List;
 import org.dwcj.bridge.WindowAccessor;
 import org.dwcj.component.AbstractOptionInput;
 import org.dwcj.component.window.AbstractWindow;
@@ -63,7 +65,7 @@ public final class CheckBox extends AbstractOptionInput<CheckBox> {
    * @return The checkbox itself
    */
   public CheckBox setIndeterminate(boolean value) {
-    setProperty("indeterminate", value);
+    setUnrestrictedProperty("indeterminate", value);
     this.indeterminate = value;
     return this;
   }
@@ -75,6 +77,21 @@ public final class CheckBox extends AbstractOptionInput<CheckBox> {
    */
   public boolean isIndeterminate() {
     return this.indeterminate;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<String> getRestrictedProperties() {
+    List<String> properties = super.getRestrictedProperties();
+    properties.addAll(Arrays.asList("autoValidate", "autoValidateOnLoad", "autoWasValidated",
+        "checked", "disabled", "expanse", "hasFocus", "indeterminate", "invalid", "invalidMessage",
+        "label", "name", "readonly", "required", "tabTraversable", "valid", "validationIcon",
+        "validationPopoverDistance", "validationPopoverPlacement", "validationPopoverSkidding",
+        "validationStyle", "validator", "value"));
+
+    return properties;
   }
 
   /**

--- a/dwcj-engine/src/main/java/org/dwcj/component/radiobutton/RadioButton.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/radiobutton/RadioButton.java
@@ -2,6 +2,7 @@ package org.dwcj.component.radiobutton;
 
 import com.basis.bbj.proxies.sysgui.BBjWindow;
 import com.basis.startup.type.BBjException;
+import java.util.Arrays;
 import java.util.List;
 import org.dwcj.bridge.WindowAccessor;
 import org.dwcj.component.AbstractOptionInput;
@@ -95,7 +96,7 @@ public final class RadioButton extends AbstractOptionInput<RadioButton> {
    * @see Activation
    */
   public RadioButton setActivation(Activation value) {
-    setProperty("activation", value.getValue());
+    setUnrestrictedProperty("activation", value.getValue());
     this.activation = value;
 
     return this;
@@ -158,6 +159,21 @@ public final class RadioButton extends AbstractOptionInput<RadioButton> {
    */
   void setButtonGroup(RadioButtonGroup group) {
     this.group = group;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<String> getRestrictedProperties() {
+    List<String> properties = super.getRestrictedProperties();
+    properties.addAll(Arrays.asList("activation", "autoValidate", "autoValidateOnLoad",
+        "autoWasValidated", "checked", "disabled", "expanse", "hasFocus", "invalid",
+        "invalidMessage", "label", "name", "readonly", "required", "switch", "tabTraversable",
+        "valid", "validationIcon", "validationPopoverDistance", "validationPopoverPlacement",
+        "validationPopoverSkidding", "validationStyle", "validator", "value"));
+
+    return properties;
   }
 
   /**

--- a/dwcj-engine/src/main/java/org/dwcj/exceptions/DwcjRestrictedAccessException.java
+++ b/dwcj-engine/src/main/java/org/dwcj/exceptions/DwcjRestrictedAccessException.java
@@ -1,0 +1,29 @@
+package org.dwcj.exceptions;
+
+/**
+ * Exception thrown when the API user is trying to access a restricted API.
+ *
+ * @author Hyyan Abo Fakher
+ * @version 23.02
+ */
+public class DwcjRestrictedAccessException extends DwcjRuntimeException {
+
+  /**
+   * Construct a new DwcjRestrictedAttribute exception.
+   *
+   * @param message the exception message
+   */
+  public DwcjRestrictedAccessException(String message) {
+    super(message);
+  }
+
+  /**
+   * Construct a new DwcjRestrictedAttribute exception.
+   *
+   * @param message the exception message
+   * @param cause the cause of the exception
+   */
+  public DwcjRestrictedAccessException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/dwcj-engine/src/test/java/org/dwcj/component/AbstractDwcComponentMock.java
+++ b/dwcj-engine/src/test/java/org/dwcj/component/AbstractDwcComponentMock.java
@@ -1,5 +1,8 @@
 package org.dwcj.component;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.dwcj.component.window.AbstractWindow;
 
 public class AbstractDwcComponentMock extends AbstractDwcComponent
@@ -25,6 +28,11 @@ public class AbstractDwcComponentMock extends AbstractDwcComponent
   @Override
   public Boolean isReadOnly() {
     return isComponentReadOnly();
+  }
+
+  @Override
+  public List<String> getRestrictedProperties() {
+    return new ArrayList<>(Arrays.asList("expanse", "readonly", "doesNotExist"));
   }
 
   @Override

--- a/dwcj-engine/src/test/java/org/dwcj/component/AbstractDwcComponentMock.java
+++ b/dwcj-engine/src/test/java/org/dwcj/component/AbstractDwcComponentMock.java
@@ -32,7 +32,7 @@ public class AbstractDwcComponentMock extends AbstractDwcComponent
 
   @Override
   public List<String> getRestrictedProperties() {
-    return new ArrayList<>(Arrays.asList("expanse", "readonly", "doesNotExist"));
+    return new ArrayList<>(Arrays.asList("expanse", "doesNotExist"));
   }
 
   @Override


### PR DESCRIPTION
The PR introduces the necessary API that enables components to have control over which attributes and properties are restricted and cannot be modified by the setAttribute/setProperty APIs