### PR TITLE
feat: Add component LifecycleObserver support

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/component/Component.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/Component.java
@@ -1,8 +1,11 @@
 package org.dwcj.component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.dwcj.component.ComponentLifecycleObserver.LifecycleEvent;
 import org.dwcj.component.window.Window;
 
 /**
@@ -22,8 +25,8 @@ import org.dwcj.component.window.Window;
  * @since 23.05
  */
 public abstract class Component {
-
   private final Map<Object, Object> userData = new HashMap<>();
+  private final List<ComponentLifecycleObserver> lifecycleObservers = new ArrayList<>();
   private String uuid = "";
   private boolean attached = false;
   private boolean destroyed = false;
@@ -98,6 +101,10 @@ public abstract class Component {
     this.destroyed = true;
     this.window = null;
     this.onDestroy();
+
+    for (ComponentLifecycleObserver observer : lifecycleObservers) {
+      observer.onComponentLifecycleEvent(this, LifecycleEvent.DESTROY);
+    }
   }
 
   /**
@@ -130,6 +137,24 @@ public abstract class Component {
    */
   public final Window getWindow() {
     return this.window;
+  }
+
+  /**
+   * Adds a listener to receive notifications about lifecycle events of the component.
+   *
+   * @param observer The listener to add
+   */
+  public void addLifecycleObserver(ComponentLifecycleObserver observer) {
+    lifecycleObservers.add(observer);
+  }
+
+  /**
+   * Removes a listener from receiving notifications about lifecycle events of the component.
+   *
+   * @param observer The listener to remove
+   */
+  public void removeLifecycleObserver(ComponentLifecycleObserver observer) {
+    lifecycleObservers.remove(observer);
   }
 
   /**
@@ -201,7 +226,12 @@ public abstract class Component {
     }
 
     this.window = window;
+
     this.onCreate(window);
+    for (ComponentLifecycleObserver observer : lifecycleObservers) {
+      observer.onComponentLifecycleEvent(this, LifecycleEvent.CREATE);
+    }
+
     this.attached = true;
     this.onAttach();
   }

--- a/dwcj-engine/src/main/java/org/dwcj/component/ComponentLifecycleObserver.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/ComponentLifecycleObserver.java
@@ -1,0 +1,33 @@
+package org.dwcj.component;
+
+/**
+ * An interface for observing lifecycle events of a component.
+ *
+ * @author Hyyan Abo Fakher
+ * @since 23.05
+ */
+@FunctionalInterface
+public interface ComponentLifecycleObserver {
+  /**
+   * Represents the lifecycle events of a component.
+   */
+  enum LifecycleEvent {
+    /**
+     * Indicates that the component has been created and attached.
+     */
+    CREATE,
+
+    /**
+     * Indicates that the component has been destroyed.
+     */
+    DESTROY
+  }
+
+  /**
+   * Called when a lifecycle event occurs for the observed component.
+   *
+   * @param component The component that triggered the event
+   * @param event The type of lifecycle event
+   */
+  void onComponentLifecycleEvent(Component component, LifecycleEvent event);
+}

--- a/dwcj-engine/src/test/java/org/dwcj/component/ComponentTest.java
+++ b/dwcj-engine/src/test/java/org/dwcj/component/ComponentTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-
+import org.dwcj.component.ComponentLifecycleObserver.LifecycleEvent;
 import org.dwcj.component.window.Window;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -101,5 +101,19 @@ class ComponentTest {
 
     spy.destroy();
     verify(spy).onDestroy();
+  }
+
+  @Test
+  @DisplayName("Test Lifecycle observers")
+  void testNotifyLifecycleObservers() throws IllegalAccessException {
+    ComponentLifecycleObserver observer = mock(ComponentLifecycleObserver.class);
+
+    component.addLifecycleObserver(observer);
+
+    component.create(null);
+    verify(observer).onComponentLifecycleEvent(component, LifecycleEvent.CREATE);
+
+    component.destroy();
+    verify(observer).onComponentLifecycleEvent(component, LifecycleEvent.DESTROY);
   }
 }

--- a/dwcj-engine/src/test/java/org/dwcj/component/ComponentTest.java
+++ b/dwcj-engine/src/test/java/org/dwcj/component/ComponentTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+
 import org.dwcj.component.ComponentLifecycleObserver.LifecycleEvent;
 import org.dwcj.component.window.Window;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
The component class allow now adding external lifecycle observers to be notified when the component is created or destroyed