### PR TITLE
feat: add `PendingResult::allOf` method

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/PendingResult.java
+++ b/dwcj-engine/src/main/java/org/dwcj/PendingResult.java
@@ -185,6 +185,25 @@ public final class PendingResult<T> {
   }
 
   /**
+   * Returns a new PendingResult that is completed when all of the given PendingResults complete. If
+   * any of the given PendingResult complete exceptionally, then the returned PendingResult also
+   * does so.
+   *
+   * @param pendingResults the PendingResults
+   * @return a new PendingResult that is completed when all of the given PendingResults complete
+   *
+   * @since 23.06
+   */
+  public static PendingResult<Void> allOf(PendingResult<?>... pendingResults) {
+    CompletableFuture<?>[] futures = new CompletableFuture<?>[pendingResults.length];
+    for (int i = 0; i < pendingResults.length; i++) {
+      futures[i] = pendingResults[i].future;
+    }
+
+    return new PendingResult<>(CompletableFuture.allOf(futures));
+  }
+
+  /**
    * Creates and returns a new PendingResult that is already completed with the provided value. This
    * method is useful for returning a pre-completed asynchronous operation, similar to
    * {@link CompletableFuture#completedFuture(Object)}.

--- a/dwcj-engine/src/test/java/org/dwcj/PendingResultTest.java
+++ b/dwcj-engine/src/test/java/org/dwcj/PendingResultTest.java
@@ -104,4 +104,18 @@ class PendingResultTest {
     assertTrue(exception.get() instanceof RuntimeException);
     assertEquals("Failure", exception.get().getMessage());
   }
+
+  @Test
+  @DisplayName("allOf should wait for all PendingResults to complete")
+  void testAllOf() {
+    PendingResult<String> first = PendingResult.completedWith("first");
+    PendingResult<String> second = PendingResult.completedWith("second");
+    PendingResult<String> third =
+        PendingResult.completedExceptionallyWith(new RuntimeException("Error"));
+
+    PendingResult<Void> combined = PendingResult.allOf(first, second, third);
+
+    assertTrue(combined.isDone());
+    assertTrue(combined.isCompletedExceptionally());
+  }
 }


### PR DESCRIPTION
The method Returns a new `PendingResult` that is completed when all of the given `PendingResults` complete. If
any of the given `PendingResult` complete exceptionally, then the returned `PendingResult` also does so.