### PR TITLE
feat: add `Component::geClientComponentId` method

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/component/Component.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/Component.java
@@ -61,6 +61,21 @@ public abstract class Component {
   }
 
   /**
+   * Retrieves the ID of the component's client-side counterpart.
+   *
+   * <p>
+   * If the component has a client-side counterpart, this method returns the ID of that component on
+   * the client side. If the component does not have a client-side counterpart, this method returns
+   * {@code null}.
+   * </p>
+   *
+   * @return The ID of the component's client-side counterpart.
+   */
+  public String geClientComponentId() {
+    return null;
+  }
+
+  /**
    * Allows users to include additional information within the component.
    *
    * <p>

--- a/dwcj-engine/src/main/java/org/dwcj/component/Component.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/Component.java
@@ -70,6 +70,7 @@ public abstract class Component {
    * </p>
    *
    * @return The ID of the component's client-side counterpart.
+   * @since 23.06
    */
   public String geClientComponentId() {
     return null;

--- a/dwcj-engine/src/main/java/org/dwcj/component/DwcComponent.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/DwcComponent.java
@@ -93,6 +93,22 @@ public abstract class DwcComponent<T extends DwcComponent<T>> extends Component
   private Enum<? extends ThemeBase> theme = null;
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String geClientComponentId() {
+    if (isAttached()) {
+      try {
+        return getControl().getClientObjectID();
+      } catch (BBjException e) {
+        throw new DwcjRuntimeException("Failed to get client object ID", e);
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Sets the underling BBj Control.
    *
    * @param control the BBj control to set.


### PR DESCRIPTION
The client component ID is auto generated ID by BBj. This method  Retrieves the ID of the component's client-side counterpart.  If the component has a client-side counterpart, this method returns the ID of that component on the client side. If the component does not have a client-side counterpart, this method returns `null`. 