### PR TITLE
feat(drawer): add support for `title`, `header-actions` and `footer` slots

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/component/drawer/Drawer.java
+++ b/dwcj-engine/src/main/java/org/dwcj/component/drawer/Drawer.java
@@ -2,6 +2,7 @@ package org.dwcj.component.drawer;
 
 import com.google.gson.annotations.SerializedName;
 import org.dwcj.annotation.ExcludeFromJacocoGeneratedReport;
+import org.dwcj.component.Component;
 import org.dwcj.component.drawer.Drawer;
 import org.dwcj.component.drawer.event.DrawerCloseEvent;
 import org.dwcj.component.drawer.event.DrawerOpenEvent;
@@ -54,17 +55,20 @@ public class Drawer extends ElementCompositeContainer
     RIGHT;
   }
 
+  // Slots
+  private static final String TITTLE_SLOT = "title";
+  private static final String HEADER_ACTIONS_SLOT = "header-actions";
+  private static final String FOOTER_SLOT = "footer";
+
+  // Property descriptors
   private final PropertyDescriptor<Boolean> autoFocusProp =
-      PropertyDescriptor.property("autoFocus", false);
+      PropertyDescriptor.property("autofocus", false);
   private final PropertyDescriptor<String> labelProp =
       PropertyDescriptor.property("label", "Drawer");
-  private final PropertyDescriptor<String> maxSizeProp =
-      PropertyDescriptor.property("maxSize", "100%");
   private final PropertyDescriptor<Boolean> openedProp =
       PropertyDescriptor.property("opened", false);
   private final PropertyDescriptor<Placement> placementProp =
       PropertyDescriptor.property("placement", Placement.LEFT);
-  private final PropertyDescriptor<String> sizeProp = PropertyDescriptor.property("size", "16em");
 
   /**
    * Instantiates a new drawer.
@@ -73,13 +77,51 @@ public class Drawer extends ElementCompositeContainer
     super();
   }
 
+  public Drawer(String label) {
+    this();
+    setLabel(label);
+  }
+
+  /**
+   * Add the given component to the title slot.
+   *
+   * @param component the component to add
+   * @return the component itself
+   */
+  public Drawer addToTitle(Component... component) {
+    getElement().add(TITTLE_SLOT, component);
+    return this;
+  }
+
+  /**
+   * Add the given component to the header actions slot.
+   *
+   * @param component the component to add
+   * @return the component itself
+   */
+  public Drawer addToHeaderActions(Component... component) {
+    getElement().add(HEADER_ACTIONS_SLOT, component);
+    return this;
+  }
+
+  /**
+   * Add the given component to the footer slot.
+   *
+   * @param component the component to add
+   * @return the component itself
+   */
+  public Drawer addToFooter(Component... component) {
+    getElement().add(FOOTER_SLOT, component);
+    return this;
+  }
+
   /**
    * Sets Drawer auto focus.
    *
    * @param autoFocus When true then automatically focus the first focusable element in the drawer.
    * @return the drawer
    */
-  public Drawer setAutoFocus(boolean autoFocus) {
+  public Drawer setAutofocus(boolean autoFocus) {
     set(autoFocusProp, autoFocus);
     return this;
   }
@@ -89,12 +131,12 @@ public class Drawer extends ElementCompositeContainer
    *
    * @return the drawer auto focus
    */
-  public boolean isAutoFocus() {
+  public boolean isAutofocus() {
     return get(autoFocusProp);
   }
 
   /**
-   * Sets Drawer label. (Used for accessibility)
+   * Sets Drawer label.
    *
    * @param label The drawer label.
    * @return the drawer
@@ -111,27 +153,6 @@ public class Drawer extends ElementCompositeContainer
    */
   public String getLabel() {
     return get(labelProp);
-  }
-
-  /**
-   * Sets Drawer max size.
-   *
-   * @param maxSize The Drawer max width. Max width in case placement is `left` or `right` or max
-   *        height in case placement is `top` or `bottom`.
-   * @return the drawer
-   */
-  public Drawer setMaxSize(String maxSize) {
-    set(maxSizeProp, maxSize);
-    return this;
-  }
-
-  /**
-   * Gets Drawer max size.
-   *
-   * @return the drawer max size
-   */
-  public String getMaxSize() {
-    return get(maxSizeProp);
   }
 
   /**
@@ -190,27 +211,6 @@ public class Drawer extends ElementCompositeContainer
    */
   public Placement getPlacement() {
     return get(placementProp);
-  }
-
-  /**
-   * Sets Drawer size.
-   *
-   * @param size The Drawer size. Width in case placement is `left` or `right` or height in case
-   *        placement is `top` or `bottom`.
-   * @return the drawer
-   */
-  public Drawer setSize(String size) {
-    set(sizeProp, size);
-    return this;
-  }
-
-  /**
-   * Gets Drawer size.
-   *
-   * @return the drawer size
-   */
-  public String getSize() {
-    return get(sizeProp);
   }
 
   /**

--- a/dwcj-engine/src/test/java/org/dwcj/component/drawer/DrawerTest.java
+++ b/dwcj-engine/src/test/java/org/dwcj/component/drawer/DrawerTest.java
@@ -3,9 +3,11 @@ package org.dwcj.component.drawer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.List;
+import org.dwcj.component.Component;
 import org.dwcj.component.drawer.event.DrawerCloseEvent;
 import org.dwcj.component.drawer.event.DrawerOpenEvent;
 import org.dwcj.component.element.PropertyDescriptorTester;
@@ -49,6 +51,33 @@ class DrawerTest {
 
       assertEquals(false, component.isOpened());
       assertEquals(false, component.getOriginalElement().getProperty("opened"));
+    }
+  }
+
+  @Nested
+  @DisplayName("Slots API")
+  class SlotsApi {
+
+    @Test
+    void shouldAddToTitle() {
+      Component title = mock(Component.class);
+      component.addToTitle(title);
+      assertEquals(title, component.getOriginalElement().getFirstComponentInSlot("title"));
+    }
+
+    @Test
+    void shouldAddToHeaderActions() {
+      Component headerActions = mock(Component.class);
+      component.addToHeaderActions(headerActions);
+      assertEquals(headerActions,
+          component.getOriginalElement().getFirstComponentInSlot("header-actions"));
+    }
+
+    @Test
+    void shouldAddToFooter() {
+      Component footer = mock(Component.class);
+      component.addToFooter(footer);
+      assertEquals(footer, component.getOriginalElement().getFirstComponentInSlot("footer"));
     }
   }
 


### PR DESCRIPTION
@MatthewHawkins please update the drawer docs, the PR:

1. Remove style methods (setSize and setMaxWidth). Css variables must be used for this (Keep the current docs, just explain the way to do it in css variables) 
2. Add support for the  `title`, `header-actions` and `footer` slots

```java
public class DrawerDemo extends App {

  Drawer drawer = new Drawer("Drawer");
  Element title = new Element("p", "This is a Drawer component!");
  Button button = new Button("Click me!");

  @Override
  public void run() throws DwcjException {

    Frame app = new Frame();
    app.add(drawer);

    drawer.open();
    drawer.add(title);
    drawer.addToFooter(button.setTheme(ButtonTheme.PRIMARY));
  }
}
```
<img width="464" alt="drawer" src="https://github.com/DwcJava/engine/assets/4313420/cad44295-c6be-49f1-87d6-f24f0ff9d9bd">

