### PR TITLE
feat: allow apps to apply themes from query params

### DIFF
--- a/dwcj-engine/src/main/java/org/dwcj/App.java
+++ b/dwcj-engine/src/main/java/org/dwcj/App.java
@@ -6,6 +6,7 @@ import com.basis.startup.type.BBjException;
 import java.net.URL;
 import org.dwcj.annotation.AnnotationProcessor;
 import org.dwcj.bridge.IDwcjBBjBridge;
+import org.dwcj.environment.StringTable;
 import org.dwcj.environment.namespace.GlobalNamespace;
 import org.dwcj.environment.namespace.GroupNamespace;
 import org.dwcj.environment.namespace.Namespace;
@@ -50,6 +51,14 @@ public abstract class App {
   public final void initialize() throws DwcjAppInitializeException {
     if (isInitialized) {
       throw new DwcjAppInitializeException("App is already initialized.");
+    }
+
+    String key = "PARSE_REQUEST_THEME";
+    if (StringTable.contains(key) && StringTable.get(key).equals("1")) {
+      String theme = Request.getQueryParam("__theme__");
+      if (theme != null) {
+        setTheme(theme);
+      }
     }
 
     preRun();

--- a/dwcj-engine/src/main/java/org/dwcj/annotation/AnnotationProcessor.java
+++ b/dwcj-engine/src/main/java/org/dwcj/annotation/AnnotationProcessor.java
@@ -332,7 +332,7 @@ public final class AnnotationProcessor {
         if (phase == RunningPhase.PRE_RUN && StringTable.contains(key)) {
 
           // is blacklisted ?
-          String[] blackList = new String[] {"DEBUG"};
+          String[] blackList = new String[] {"DEBUG", "PARSE_REQUEST_THEME"};
           if (Arrays.asList(blackList).contains(key)) {
             continue;
           }

--- a/dwcj-engine/src/main/java/org/dwcj/utilities/WelcomeApp.java
+++ b/dwcj-engine/src/main/java/org/dwcj/utilities/WelcomeApp.java
@@ -23,6 +23,7 @@ public class WelcomeApp extends App {
   private Frame panel;
   private String baseUrl = "";
   private String urlTail = "";
+  private String urlTailWithoutParam = "";
 
   /**
    * The App that is used as an index page when multiple classes extend App and none is pinned in
@@ -52,6 +53,12 @@ public class WelcomeApp extends App {
         urlTail = urlTail.substring(0, urlTail.indexOf("/"));
       }
 
+      int questionMarkPosition = urlTail.indexOf("?");
+      if (questionMarkPosition != -1) {
+        urlTailWithoutParam = urlTail.substring(0, questionMarkPosition);
+      } else {
+        urlTailWithoutParam = urlTail;
+      }
     }
 
     buildAppList();
@@ -94,10 +101,10 @@ public class WelcomeApp extends App {
       }
 
       // determine if route contains some application that can be launched
-      if (!this.urlTail.isBlank()) {
+      if (!this.urlTailWithoutParam.isBlank()) {
         for (String entry : applist) {
           try {
-            if (Class.forName(entry).getSimpleName().equals(this.urlTail)) {
+            if (Class.forName(entry).getSimpleName().equals(this.urlTailWithoutParam)) {
               // store base url in object table so that interested partied know of the automatic
               // forwarding
               ObjectTable.put("dwcj_base_url", this.baseUrl + "/" + this.urlTail);


### PR DESCRIPTION
@MatthewHawkins

This enhancement  is for the documentation site. With this update, applications can automatically detect the application theme based on the query parameter `__theme__`. For this feature to function, the STBL configuration `PARSE_REQUEST_THEME=1` must be included in `config.bbx`. Please test this adjustment with the documentation and provide feedback regarding any encountered issues.

